### PR TITLE
fix search error, when adult files showed

### DIFF
--- a/resources/language/Czech/strings.xml
+++ b/resources/language/Czech/strings.xml
@@ -38,6 +38,7 @@
 	<string id="30061">Audio</string>
 	<string id="30062">Dokumenty</string>
 	<string id="30063">Další stránka</string>
+	<string id="30064">Erotický obsah</string>
 
 	<string id="31000">Data o použití jsou zaslána v okamžiku, kdy spustíte přehrávání nebo stahování videa doplňkem. Není odesílána informace o tom, co přehráváte.</string>
 </strings>

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -39,5 +39,7 @@
 	<string id="30061">Audio</string>
 	<string id="30062">Documents</string>
 	<string id="30063">Next Page</string>
+	<string id="30064">Adult content</string>
+
 	<string id="31000">Usage of plugin is tracked whenever you play or download video. We do NOT track what has been played</string>
 </strings>

--- a/resources/language/Slovak/strings.xml
+++ b/resources/language/Slovak/strings.xml
@@ -38,5 +38,6 @@
 	<string id="30061">Audio</string>
 	<string id="30062">Dokumenty</string>
 	<string id="30063">Ďalšia stránka</string>
+	<string id="30064">Erotický obsah</string>
 	<string id="31000">Údaje o použití sú zaslané iba v okamihu, keď spustíte prehrávanie alebo sťahovanie videa doplnkom.</string>
 </strings>

--- a/resources/lib/hellspy.py
+++ b/resources/lib/hellspy.py
@@ -20,9 +20,13 @@
 # *
 # */
 import re,urllib,urllib2,cookielib,random,util,sys,os,traceback
-import simplejson as json
+import simplejson as json, xbmcaddon
 from base64 import b64decode
 from provider import ContentProvider
+
+__scriptid__   = 'plugin.video.online-files'
+__addon__      = xbmcaddon.Addon(id=__scriptid__)
+__settings__   = __addon__.getSetting
 
 class HellspyContentProvider(ContentProvider):
 
@@ -35,7 +39,7 @@ class HellspyContentProvider(ContentProvider):
         return ['login','search','resolve','categories']
 
     def search(self,keyword):
-        return self.list('search/?adultControl-state=1&do=adultControl-confirmed&usrq='+urllib.quote(keyword))
+        return self.list('search/?usrq='+urllib.quote(keyword))
 
     def login(self):
         if self.username and self.password and len(self.username)>0 and len(self.password)>0:
@@ -81,24 +85,35 @@ class HellspyContentProvider(ContentProvider):
         url = self._url(url)
         util.init_urllib()
         page = util.request(url)
+
+        adult = '0'
+        if __settings__('hellspy_adult') == 'true':
+            adult = '1'
+
+        if page.find('adultWarn-') > 0:
+            page = util.request(url + '&adultControl-state=' + adult + '&do=adultControl-confirmed')
+
         data = util.substr(page,'<div class=\"file-list file-list-horizontal','<div id=\"layout-push')
         result = []
         for m in re.finditer('<div class=\"file-entry.+?<div class="preview.+?<div class=\"data.+?</div>',data, re.IGNORECASE|re.DOTALL):
             entry = m.group(0)
             item = self.video_item()
             murl = re.search('<[hH]3><a href=\"(?P<url>[^\"]+)[^>]+>(?P<name>[^<]+)',entry)
-            item['url'] = murl.group('url')
-            item['title'] = murl.group('name')
-            mimg = re.search('<img src=\"(?P<img>[^\"]+)',entry)
-            if mimg:	
-                item['img'] = mimg.group('img')
-            msize = re.search('<span class=\"file-size[^>]+>(?P<size>[^<]+)',entry)
-            if msize:
-                item['size'] = msize.group('size').strip()
-            mtime = re.search('<span class=\"duration[^>]+>(?P<time>[^<]+)',entry)
-            if mtime:
-                item['length'] = mtime.group('time').strip()
-            self._filter(result,item)
+
+            if murl:
+	            item['url'] = murl.group('url')
+	            item['title'] = murl.group('name')
+	            mimg = re.search('<img src=\"(?P<img>[^\"]+)',entry)
+	            if mimg:	
+	                item['img'] = mimg.group('img')
+	            msize = re.search('<span class=\"file-size[^>]+>(?P<size>[^<]+)',entry)
+	            if msize:
+	                item['size'] = msize.group('size').strip()
+	            mtime = re.search('<span class=\"duration[^>]+>(?P<time>[^<]+)',entry)
+	            if mtime:
+	                item['length'] = mtime.group('time').strip()
+            	self._filter(result,item)
+            	
         # page navigation
         data = util.substr(page,'<div class=\"paginator','</div')
         mprev = re.search('<li class=\"prev[^<]+<a href=\"(?P<url>[^\"]+)',data)

--- a/resources/lib/hellspy.py
+++ b/resources/lib/hellspy.py
@@ -35,7 +35,7 @@ class HellspyContentProvider(ContentProvider):
         return ['login','search','resolve','categories']
 
     def search(self,keyword):
-        return self.list('search/?usrq='+urllib.quote(keyword))
+        return self.list('search/?adultControl-state=1&do=adultControl-confirmed&usrq='+urllib.quote(keyword))
 
     def login(self):
         if self.username and self.password and len(self.username)>0 and len(self.password)>0:

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -28,6 +28,7 @@
 		<setting label="30000" id="hellspy_keep-searches" type="text" default="20" />
 		<setting label="30007" id="hellspy_user" type="text" default="" />
 		<setting label="30008" id="hellspy_pass" type="text" default="" option="hidden" />
+		<setting label="30064" id="hellspy_adult" type="bool" default="false" />
 	</category>
 	<category label="30014">
 		<setting label="30002" id="fastshare_enabled" type="bool" default="true" />


### PR DESCRIPTION
When an adult file appeared between the results, there was an error. Modified to view non-adult. May be added in the future to whether adult files should be displayed or not.